### PR TITLE
Try to fix building for arm64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.exe~
 *.dll
 *.so
+*.o
 *.dylib
 
 # Test binary, built with `go test -c`

--- a/Makefile
+++ b/Makefile
@@ -4,36 +4,80 @@ GIT_COMMIT := $(shell git rev-parse HEAD)
 BUILD_TIME := $(shell date +"%Y-%m-%d %H:%M:%S %Z")
 LDFLAGS := "-w -s"
 
+ARCH := $(shell uname -m)
+
 .PHONY: build all_build init_env build_amd64 build_arm64
 build:
-	@echo "Building watchmaker..."
+	@echo "===> Building watchmaker on $(ARCH) host..."
 	@docker run -it --rm --network host -v $(shell pwd):/go/src/watchmaker -w /go/src/watchmaker golang:latest make all_build
 
 all_build: init_env build_amd64 build_arm64
 
-init_env:
-	@echo "Initializing environment..."
-	@apt update && apt install -y gcc-aarch64-linux-gnu git tar xz-utils \
+.PHONY: init_env_x86_64
+init_env_x86_64:
+	@echo "===> Initializing environment ($(ARCH))..."
+	@apt update && apt install -y gcc-12-aarch64-linux-gnu git tar xz-utils \
 	&& wget https://github.com/upx/upx/releases/download/v5.0.0/upx-5.0.0-amd64_linux.tar.xz \
 	&& tar -xf upx-5.0.0-amd64_linux.tar.xz \
 	&& mv upx-5.0.0-amd64_linux/upx /usr/local/bin/upx \
 	&& rm -rf upx-5.0.0-amd64_linux*
 
-build_amd64:
-	@echo "Building watchmaker_linux_amd64..."
-	@cc -c fakeclock/fake_clock_gettime.c -fPIE -O2 -o fakeclock/fake_clock_gettime_amd64.o
-	@cc -c fakeclock/fake_gettimeofday.c -fPIE -O2 -o fakeclock/fake_gettimeofday_amd64.o
-	@cc -c fakeclock/fake_time.c -fPIE -O2 -o fakeclock/fake_time_amd64.o
-	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags $(LDFLAGS) -o bin/watchmaker_linux_amd64 ./cmd/...
-	@upx --lzma bin/watchmaker_linux_amd64
+.PHONY: init_env_arm64
+init_env_arm64:
+	@echo "===> Initializing environment ($(ARCH))..."
+	@apt update && apt install -y gcc-12-x86-64-linux-gnu git tar xz-utils \
+	&& wget https://github.com/upx/upx/releases/download/v5.0.0/upx-5.0.0-arm64_linux.tar.xz \
+	&& tar -xf upx-5.0.0-arm64_linux.tar.xz \
+	&& mv upx-5.0.0-arm64_linux/upx /usr/local/bin/upx \
+	&& rm -rf upx-5.0.0-arm64_linux*
 
-build_arm64:
-	@echo "Building watchmaker_linux_arm64..."
-	@aarch64-linux-gnu-gcc -c fakeclock/fake_clock_gettime.c -fPIE -O2 -o fakeclock/fake_clock_gettime_arm64.o
-	@aarch64-linux-gnu-gcc -c fakeclock/fake_gettimeofday.c -fPIE -O2 -o fakeclock/fake_gettimeofday_arm64.o
-	@aarch64-linux-gnu-gcc -c fakeclock/fake_time.c -fPIE -O2 -o fakeclock/fake_time_arm64.o
-	@CGO_ENABLED=0 CC=aarch64-linux-gnu-gcc GOOS=linux GOARCH=arm64 go build -trimpath -ldflags $(LDFLAGS) -o bin/watchmaker_linux_arm64 ./cmd/...
-	@upx --lzma bin/watchmaker_linux_arm64
+init_env_aarch64: init_env_arm64
+
+init_env: init_env_$(ARCH)
+
+.PHONY: build_amd64_x86_64
+build_amd64_x86_64:
+	@echo "===> Building watchmaker_linux_amd64 on $(ARCH)..."
+	gcc -c fakeclock/fake_clock_gettime.c -fPIE -O2 -o fakeclock/fake_clock_gettime_amd64.o
+	gcc -c fakeclock/fake_gettimeofday.c -fPIE -O2 -o fakeclock/fake_gettimeofday_amd64.o
+	gcc -c fakeclock/fake_time.c -fPIE -O2 -o fakeclock/fake_time_amd64.o
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags $(LDFLAGS) -o bin/watchmaker_linux_amd64 ./cmd/...
+	upx --lzma bin/watchmaker_linux_amd64
+
+.PHONY: build_amd64_arm64
+build_amd64_arm64:
+	@echo "===> Building watchmaker_linux_amd64 on $(ARCH)..."
+	x86_64-linux-gnu-gcc-12 -c fakeclock/fake_clock_gettime.c -fPIE -O2 -o fakeclock/fake_clock_gettime_amd64.o
+	x86_64-linux-gnu-gcc-12 -c fakeclock/fake_gettimeofday.c -fPIE -O2 -o fakeclock/fake_gettimeofday_amd64.o
+	x86_64-linux-gnu-gcc-12 -c fakeclock/fake_time.c -fPIE -O2 -o fakeclock/fake_time_amd64.o
+	CGO_ENABLED=0 CC=x86_64-linux-gnu-gcc-12 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags $(LDFLAGS) -o bin/watchmaker_linux_amd64 ./cmd/...
+	upx --lzma bin/watchmaker_linux_amd64
+
+build_amd64_aarch64: build_amd64_arm64
+
+build_amd64: build_amd64_$(ARCH)
+
+.PHONY: build_arm64_x86_64
+build_arm64_x86_64:
+	@echo "===> Building watchmaker_linux_arm64 on $(ARCH)..."
+	aarch64-linux-gnu-gcc-12 -c fakeclock/fake_clock_gettime.c -fPIE -O2 -o fakeclock/fake_clock_gettime_arm64.o
+	aarch64-linux-gnu-gcc-12 -c fakeclock/fake_gettimeofday.c -fPIE -O2 -o fakeclock/fake_gettimeofday_arm64.o
+	aarch64-linux-gnu-gcc-12 -c fakeclock/fake_time.c -fPIE -O2 -o fakeclock/fake_time_arm64.o
+	CGO_ENABLED=0 CC=aarch64-linux-gnu-gcc-12 GOOS=linux GOARCH=arm64 go build -trimpath -ldflags $(LDFLAGS) -o bin/watchmaker_linux_arm64 ./cmd/...
+	upx --lzma bin/watchmaker_linux_arm64
+
+.PHONY: build_arm64_arm64
+build_arm64_arm64:
+	@echo "===> Building watchmaker_linux_arm64 on $(ARCH)..."
+	gcc -c fakeclock/fake_clock_gettime.c -fPIE -O2 -o fakeclock/fake_clock_gettime_arm64.o
+	gcc -c fakeclock/fake_gettimeofday.c -fPIE -O2 -o fakeclock/fake_gettimeofday_arm64.o
+	gcc -c fakeclock/fake_time.c -fPIE -O2 -o fakeclock/fake_time_arm64.o
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -trimpath -ldflags $(LDFLAGS) -o bin/watchmaker_linux_arm64 ./cmd/...
+	upx --lzma bin/watchmaker_linux_arm64
+
+build_arm64_aarch64: build_arm64_arm64
+
+build_arm64: build_arm64_$(ARCH)
 
 clean:
 	rm -f fakeclock/*.o

--- a/Makefile
+++ b/Makefile
@@ -31,5 +31,10 @@ build_arm64:
 	@echo "Building watchmaker_linux_arm64..."
 	@aarch64-linux-gnu-gcc -c fakeclock/fake_clock_gettime.c -fPIE -O2 -o fakeclock/fake_clock_gettime_arm64.o
 	@aarch64-linux-gnu-gcc -c fakeclock/fake_gettimeofday.c -fPIE -O2 -o fakeclock/fake_gettimeofday_arm64.o
+	@aarch64-linux-gnu-gcc -c fakeclock/fake_time.c -fPIE -O2 -o fakeclock/fake_time_arm64.o
 	@CGO_ENABLED=0 CC=aarch64-linux-gnu-gcc GOOS=linux GOARCH=arm64 go build -trimpath -ldflags $(LDFLAGS) -o bin/watchmaker_linux_arm64 ./cmd/...
 	@upx --lzma bin/watchmaker_linux_arm64
+
+clean:
+	rm -f fakeclock/*.o
+	rm -rf bin

--- a/fake_image_linux_arm64.go
+++ b/fake_image_linux_arm64.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-const timeSkewFakeImage = "fake_time_amd64.o"
+const timeSkewFakeImage = "fake_time_arm64.o"
 
 // clockGettimeSkewFakeImage is the filename of fake image after compiling
 const clockGettimeSkewFakeImage = "fake_clock_gettime_arm64.o"

--- a/fakeclock/fake_clock_gettime_amd64.o
+++ b/fakeclock/fake_clock_gettime_amd64.o
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cd4dc5817be0b13bb90003086af744da1c5e2f47b9714cab6b8663633d506a08
-size 1496

--- a/fakeclock/fake_clock_gettime_arm64.o
+++ b/fakeclock/fake_clock_gettime_arm64.o
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4eefdf50426abef30856e099eacef569bd27def0e4e7e0221575bec4c650772e
-size 1776

--- a/fakeclock/fake_gettimeofday_amd64.o
+++ b/fakeclock/fake_gettimeofday_amd64.o
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:92564f95e8a90f7408060dc811848d2f469b887a8299c9887ace9d58e2a18d56
-size 1464

--- a/fakeclock/fake_gettimeofday_arm64.o
+++ b/fakeclock/fake_gettimeofday_arm64.o
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c3ac59825689438634ab32ea5a3eaf296404ebc16c27727894ec31d4055d119f
-size 1704

--- a/fakeclock/fake_time.c
+++ b/fakeclock/fake_time.c
@@ -18,6 +18,11 @@ inline time_t real_time(time_t *t) {
     return (time_t)ret;
 }
 #elif defined(__aarch64__)
+// apparently this is wrong as it taken from x86_64-linux-gnu/asm/unistd_64.h
+// of linux-libc-dev:amd64
+#ifndef __NR_time
+#define __NR_time 201
+#endif
 inline time_t real_time(time_t *t) {
     register long ret __asm__("x0") = (long)t;
     register long x8 __asm__("x8") = __NR_time;

--- a/fakeclock/fake_time_amd64.o
+++ b/fakeclock/fake_time_amd64.o
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:39e34fd5e5f0a7328ac67456300f978cc3d0983b9cf25a351d738901c1d7c5d9
-size 1392


### PR DESCRIPTION
Hi @xmapst!

I was trying to give your project a try in arm64 linux environment and noticed that the original release binary wasn't even trying to adjust `CLOCK_REALTIME` with the following error:

```
root@7cb9c2547f6b:/# watchmaker --pid 1 --faketime +300
2025/05/01 12:20:56 watchmaker.go:44: pid: 1 faketime: +300 clockids: CLOCK_REALTIME
2025/05/01 12:20:56 watchmaker.go:58: load fake image err: *fs.PathError read file from embedded fs fakeclock/fake_time_amd64.o
```

I found out that the referenced object was indeed missing, and tried to fix it in Makefile + fake_image_linux_arm64.go, but then I encountered another issue:

```
Building watchmaker_linux_arm64...
fakeclock/fake_time.c: In function 'real_time':
fakeclock/fake_time.c:28:38: error: '__NR_time' undeclared (first use in this function)
   28 |     register long x8 __asm__("x8") = __NR_time;
      |                                      ^~~~~~~~~
fakeclock/fake_time.c:28:38: note: each undeclared identifier is reported only once for each function it appears in
make: *** [Makefile:34: build_arm64] Error 1
make: *** [build] Error 2
```

So I went further and attempted to set that constant value to the one from x86_64 buildenv. That way arm64 binary was built but doesn't seem to work. I tried to run compiled go binary from this simple code:

```golang
package main

import "fmt"
import "time"

func main() {
    for {
        dt := time.Now()
        fmt.Println("Current date and time is: ", dt.String())
        time.Sleep(1*time.Second)
    }
}
```

and then do things like `watchmaker --pid my_pid --faketime +300`. No errors with loading embedded code, but no results whatsoever.

Is it supposed to work under arm64 linux?

PS: I also noticed that Makefile is not suited to run targets on arm64 host (like m1 mac) but that's okay, I do have spare intel laptop where everything worked as expected; made it work on both architectures here - https://github.com/xmapst/watchmaker/pull/1/commits/8e0d5212da7d8b3777311b53df6e45762da18ba1.